### PR TITLE
CMakeLists build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ add_subdirectory(keylib)
 
 target_include_directories(dstulib PRIVATE ${OPENSSL_INCLUDE_DIR})
 
-find_library(ICONV_LIBRARY NAMES iconv libiconv)
+find_package(Iconv REQUIRED)
 target_link_libraries(keylib PRIVATE ${ICONV_LIBRARY})
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,6 @@ add_subdirectory(dstulib)
 add_subdirectory(engine)
 add_subdirectory(keylib)
 
-target_include_directories(dstulib PRIVATE ${OPENSSL_INCLUDE_DIR})
-
-find_package(Iconv REQUIRED)
-target_link_libraries(keylib PRIVATE ${ICONV_LIBRARY})
-
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ add_subdirectory(dstulib)
 add_subdirectory(engine)
 add_subdirectory(keylib)
 
+target_include_directories(dstulib PRIVATE ${OPENSSL_INCLUDE_DIR})
+
+find_library(ICONV_LIBRARY NAMES iconv libiconv)
+target_link_libraries(keylib PRIVATE ${ICONV_LIBRARY})
+
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/dstulib/CMakeLists.txt
+++ b/dstulib/CMakeLists.txt
@@ -1,5 +1,8 @@
+find_package(OpenSSL 1.1.0 REQUIRED)
+
 add_library(dstulib OBJECT key.c asn1.c compress.c params.c)
 target_include_directories(dstulib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(dstulib PRIVATE ${OPENSSL_INCLUDE_DIR})
 set_target_properties(dstulib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(CLANG_TIDY_EXE)

--- a/keylib/CMakeLists.txt
+++ b/keylib/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(OpenSSL 1.1.0 REQUIRED)
+find_package(Iconv REQUIRED)
 
 add_library(keylib SHARED key6.c iit_asn1.c jks.c pkcs12.c keystore.c utils.c attrcurvespec_asn1.c)
-target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto)
+target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto ${ICONV_LIBRARY})
 
 if(CLANG_TIDY_EXE)
     set_target_properties(keylib PROPERTIES C_CLANG_TIDY "${DO_CLANG_TIDY}")

--- a/keylib/CMakeLists.txt
+++ b/keylib/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(OpenSSL 1.1.0 REQUIRED)
 find_package(Iconv REQUIRED)
 
 add_library(keylib SHARED key6.c iit_asn1.c jks.c pkcs12.c keystore.c utils.c attrcurvespec_asn1.c)
-target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto ${ICONV_LIBRARY})
+target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto Iconv::Iconv)
 
 if(CLANG_TIDY_EXE)
     set_target_properties(keylib PROPERTIES C_CLANG_TIDY "${DO_CLANG_TIDY}")


### PR DESCRIPTION
When I build the project from the scratch (MacOS 14.7, ARM64) I get two errors:

**Error 1:**
```
dstu-engine/dstulib/asn1.h:9:10: fatal error: 'openssl/asn1.h' file not found
```

**Error 2:**
```
[ 69%] Linking C shared library libkeylib.dylib
Undefined symbols for architecture arm64:
  "_iconv", referenced from:
      _toUTF16BE in jks.c.o
      _toUTF16BE in jks.c.o
  "_iconv_close", referenced from:
      _toUTF16BE in jks.c.o
      _toUTF16BE in jks.c.o
      _toUTF16BE in jks.c.o
  "_iconv_open", referenced from:
      _toUTF16BE in jks.c.o
ld: symbol(s) not found for architecture arm64
```

Fixed by adding include and lib directories explicitly to CMakeList.txt