### PR TITLE
Fix OSX build.

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,18 +1,42 @@
 name: Build and test
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+              name: "Ubuntu Latest, gcc",
+              os: "ubuntu-latest",
+              build_type: "Release",
+              cc: "gcc",
+              cxx: "g++",
+              args: ""
+            }
+          - {
+              name: "Ubuntu Latest, clang",
+              os: "ubuntu-latest",
+              build_type: "Release",
+              cc: "clang",
+              cxx: "clang++",
+              args: ""
+            }
+          - {
+              name: "MacOS Latest, clang",
+              os: "macos-latest",
+              build_type: "Release",
+              cc: "clang",
+              cxx: "clang++",
+              args: "-DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DOPENSSL_LIBRARIES=$(brew --prefix openssl)/lib -DOPENSSL_ENGINES_DIR=$(brew --prefix openssl)/lib"
+            }
 
     steps:
     - uses: actions/checkout@v2
@@ -30,20 +54,20 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTS=ON -DENABLE_CODECOV=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DBUILD_TESTS=ON -DENABLE_CODECOV=ON ${{ matrix.config.args }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config ${{ matrix.config.build_type }}
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C ${{ matrix.config.build_type }}
 
     - name: Install lcov
       run: sudo apt install lcov

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -67,7 +67,12 @@ jobs:
       run: ctest -C ${{ matrix.config.build_type }}
 
     - name: Install lcov
+      if: matrix.config.os == 'ubuntu-latest'
       run: sudo apt install lcov
+
+    - name: Install lcov
+      if: matrix.config.os == 'macos-latest'
+      run: brew install lcov
 
     - name: Generate coverage report
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -2,9 +2,6 @@ name: Build and test
 
 on: [push, pull_request]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-
 jobs:
   build:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -76,6 +76,17 @@ jobs:
 
     - name: Generate coverage report
       working-directory: ${{runner.workspace}}/build
+      if: matrix.config.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        lcov --capture --directory . --output-file coverage.info
+        lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
+        lcov --remove coverage.info '**/tests/**' --output-file coverage.info # filter tests
+        lcov --list coverage.info # debug info
+
+    - name: Generate coverage report
+      working-directory: ${{runner.workspace}}/build
+      if: matrix.config.os == 'macos-latest'
       shell: bash
       run: |
         lcov --capture --directory . --output-file coverage.info --ignore-errors=inconsistent,mismatch,negative,unused

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -78,10 +78,10 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: |
-        lcov --capture --directory . --output-file coverage.info
-        lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
-        lcov --remove coverage.info '**/tests/**' --output-file coverage.info # filter tests
-        lcov --list coverage.info # debug info
+        lcov --capture --directory . --output-file coverage.info --ignore-errors=inconsistent,mismatch,negative,unused
+        lcov --remove coverage.info '/usr/*' --output-file coverage.info --ignore-errors=inconsistent,mismatch,negative,unused # filter system-files
+        lcov --remove coverage.info '**/tests/**' --output-file coverage.info --ignore-errors=inconsistent,mismatch,negative,unused # filter tests
+        lcov --list coverage.info --ignore-errors=inconsistent,mismatch,negative,unused # debug info
 
     - name: Codecov
       uses: codecov/codecov-action@v1.0.14

--- a/dstulib/CMakeLists.txt
+++ b/dstulib/CMakeLists.txt
@@ -1,6 +1,9 @@
+find_package(OpenSSL 1.1.0 REQUIRED)
+
 add_library(dstulib OBJECT key.c asn1.c compress.c params.c)
 target_include_directories(dstulib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(dstulib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(dstulib PRIVATE OpenSSL::Crypto)
 
 if(CLANG_TIDY_EXE)
     set_target_properties(dstulib PROPERTIES C_CLANG_TIDY "${DO_CLANG_TIDY}")

--- a/keylib/CMakeLists.txt
+++ b/keylib/CMakeLists.txt
@@ -1,7 +1,9 @@
 find_package(OpenSSL 1.1.0 REQUIRED)
 
+find_package(Iconv)
+
 add_library(keylib SHARED key6.c iit_asn1.c jks.c pkcs12.c keystore.c utils.c attrcurvespec_asn1.c)
-target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto)
+target_link_libraries(keylib PUBLIC dstulib coverage_config OpenSSL::Crypto Iconv::Iconv)
 
 if(CLANG_TIDY_EXE)
     set_target_properties(keylib PROPERTIES C_CLANG_TIDY "${DO_CLANG_TIDY}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(OpenSSL 1.1.0 REQUIRED)
 
 add_library(common OBJECT signverify.cpp block.cpp hex.cpp error.cpp)
 target_include_directories(common PRIVATE "${CMAKE_SOURCE_DIR}/keylib")
+target_link_libraries(common PRIVATE OpenSSL::Crypto)
 
 add_executable(test_engine test.cpp)
 target_link_libraries(test_engine PUBLIC common keylib coverage_config OpenSSL::Crypto)


### PR DESCRIPTION
OSX uses LibreSSL on system level, and it is only for internal use. User applications should use custom OpenSSL build - from MacPorts, Brew or cutom built. Due to CMake limitations, it is not enough to specify `OPENSSL_ROOT_DIR`, it is also necessary to specify `OPENSSL_LIBRARIES` and `OPENSSL_ENGINES_DIR`.

Also, OSX libc does not provide `iconv`, it is provided by a separate library.

The command to build the project:
```
cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@3/3.0.8 -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@3/3.0.8/lib/ -DOPENSSL_ENGINES_DIR=/usr/local/Cellar/openssl@3/3.0.8/lib -DBUILD_TESTS=ON ..
```